### PR TITLE
fix: performance bottleneck on save to cache

### DIFF
--- a/libs/neows/src/lib/utils/get-neows-feed.ts
+++ b/libs/neows/src/lib/utils/get-neows-feed.ts
@@ -74,6 +74,8 @@ export async function getDailyNeowsFeed(params?: {
     res,
   });
 
+  neowsCache.saveToCache();
+
   return res;
 }
 
@@ -159,6 +161,8 @@ export async function getMonthlyNeowsFeed(params?: {
       year: DateTime.now().year,
       res,
     });
+
+    neowsCache.saveToCache();
 
     return res;
   }

--- a/libs/neows/src/lib/utils/get-neows.ts
+++ b/libs/neows/src/lib/utils/get-neows.ts
@@ -32,5 +32,7 @@ export async function getNeows(params: {
 
   neowsCache.setById(res);
 
+  neowsCache.saveToCache();
+
   return res;
 }

--- a/libs/neows/src/lib/utils/neows-cache.ts
+++ b/libs/neows/src/lib/utils/neows-cache.ts
@@ -159,7 +159,6 @@ export class NeowsCache {
     const { date, res } = params;
     this.dailyCache.set(date, res);
     this.setMultipleById(this.collapseNeowsResponse(res));
-    this.saveToCache();
     return this;
   }
 
@@ -213,7 +212,6 @@ export class NeowsCache {
     const { week, year, res } = params;
     this.weeklyCache.set(`${year}-${week}`, res);
     this.setMultipleById(this.collapseNeowsResponse(res));
-    this.saveToCache();
     return this;
   }
 
@@ -277,7 +275,6 @@ export class NeowsCache {
     const { month, year, res } = params;
     this.monthlyCache.set(`${year}-${month}`, res);
     this.setMultipleById(this.collapseNeowsResponse(res));
-    this.saveToCache();
     return this;
   }
 
@@ -337,7 +334,6 @@ export class NeowsCache {
    */
   public setById(res: LookupResponse) {
     this.idCache.set(res.id, res);
-    this.saveToCache();
     return this;
   }
 


### PR DESCRIPTION
**What changes did you make? (Give an overview)**

- optimized calls to localStorage to be done at the end of any batched call, rather than for each nested individual action. This should dramatically improve initial load performance. This should allow the app to keep the monthly call

**Which issue (if any) does this pull request address?**

Closes #17
