### PR TITLE
fix: add block if no api-key

### DIFF
--- a/tools/build-api-config.js
+++ b/tools/build-api-config.js
@@ -36,6 +36,12 @@ const { writeFile, stat, mkdir } = fs;
         )
       );
 
+    // perform a sanity check
+    if (!process.env.API_KEY) {
+      console.error('API_KEY is not set, cannot continue');
+      process.exit(1);
+    }
+
     await Promise.all([
       writeJsonFile('dist/api-config.json'),
       writeJsonFile('storybook-public/api-config.json'),


### PR DESCRIPTION
**What changes did you make? (Give an overview)**

- update the build-api-config script to throw and exit with an error if no API_KEY variable is actually available. 
